### PR TITLE
fix id misreference in select_all query

### DIFF
--- a/sanic_forum/api/users/queries/select_all.sql
+++ b/sanic_forum/api/users/queries/select_all.sql
@@ -1,4 +1,4 @@
-SELECT id, username
+SELECT uuid, username
 FROM auth.user
 LIMIT $limit
 OFFSET $offset;


### PR DESCRIPTION
Issue caused GET requests made to `v1/users` to result in a 500 error caused due to the executor querying for an unexisting ID column

Issue is present [here](https://github.com/prryplatypus/sanic-forum/blob/main/sanic_forum/api/users/v1.py#L19-L22):

```python
async def list_all_users(_: Request, pagination: Pagination) -> HTTPResponse:
    executor = Mayim.get(UserExecutor)
    users = await executor.select_all(pagination.limit, pagination.offset)
    return json([user.serialize(ApiVersion.V1) for user in **users])**
```

Either this or `auth.user` table schema is outdated:

```sql

CREATE TABLE auth.user (
    uuid UUID DEFAULT uuid_generate_v4(),
    username CITEXT NOT NULL,
    CONSTRAINT pk_user PRIMARY KEY (uuid),
    CONSTRAINT uk_username UNIQUE (username)
);
```

Last time this was edited seems to have been on 2022/06/27